### PR TITLE
Make links explicit in text-only version

### DIFF
--- a/media/docs-thursday.md
+++ b/media/docs-thursday.md
@@ -135,45 +135,45 @@ source: https://uxplanet.org/getting-real-about-delightful-design-24af65ebbe93
 
 ---
 
-_Beyond the README: Creating Effective Documentation for Your Project by Rand McKinney, IBM_ ([link](https://www.youtube.com/watch?v=NwUWuD9Idv4)) 21m video
+[_Beyond the README: Creating Effective Documentation for Your Project by Rand McKinney, IBM_](https://www.youtube.com/watch?v=NwUWuD9Idv4) 21m video
 
 With 25 years of experience writting developer documentation, McKinney provides motivation, strategies, and practical applications for writting developer documentation. He introduces the 2 audiences for developer documentation: contributors and users with an emphasis on the latter.
 
 ---
 
-_Loopback Readme Guidelines_ ([link](https://loopback.io/doc/en/contrib/README-guidelines.html))
+[_Loopback Readme Guidelines_](https://loopback.io/doc/en/contrib/README-guidelines.html)
 
 Altough this might be a bit to verbose for starter documenation, as it perhaps focuses on contributors, it has some great advice about what should be in a readme file and how it should be formatted.
 
 ---
 
-_A Look Into Static Site Generators For Open Source Docs by Carolyn Stransky_ ([link](https://www.youtube.com/watch?v=_2hbcnEIqrA&t=20s)) 24m video
+[_A Look Into Static Site Generators For Open Source Docs by Carolyn Stransky_](https://www.youtube.com/watch?v=_2hbcnEIqrA&t=20s) 24m video
 
 A review of 46 polled open source projects, from small home-grown to very large projects. Some key takeaways are most projects are concerned with conributor experinence, the community of the static site gen, and automation. Interesting was that language was not a preference but rather having a less steep learning curve was key. Most projects interviewed cited that they were happiest when using a variety of tools that fit their specific needs.
 
 ---
 
-_The Art of Documentation and Readme.md for Open Source Projects - Ben Hall_ ([link](https://www.youtube.com/watch?v=-EaJEnFhwjs&t=5s)) 35m video
+[_The Art of Documentation and Readme.md for Open Source Projects - Ben Hall_](https://www.youtube.com/watch?v=-EaJEnFhwjs&t=5s) 35m video
 
 TODO: write summary
 
 ---
 
-_Write The Docs_ ([link](https://www.writethedocs.org))
+[_Write The Docs_](https://www.writethedocs.org))
 
 Podcasts, Confrences, Slack Community of Techinical Writers. A huge amount of resources.
 
-_How to build a website with github_ ([link tutorial](https://github.com/mapzen/write-the-docs-tutorial) [link video](https://www.youtube.com/watch?v=812E14gFgb4)) 1h28m - video
+[_How to build a website with github_](https://github.com/mapzen/write-the-docs-tutorial). [_How to build a website with github, video](https://www.youtube.com/watch?v=812E14gFgb4) 1h28m - video
 
 If you are not a developer, this provides a good walkthrough for setting up github pages / jekyll. Video and demo are targeted towards Technical Writers at the Write The Docs conference.
 
 ---
 
-_Write the Readable README by Daniel D. Beck_ ([link](https://www.youtube.com/watch?v=2dAK42B7qtw)) 23m video
+[_Write the Readable README by Daniel D. Beck_](https://www.youtube.com/watch?v=2dAK42B7qtw) 23m video
 
 In this video Beck did a survey of over 200 public opensource readme files from projects with over 10k stars on github, projects he was familair with, and some closed source readmes. Bias is towards established popular products.
 
-_README Checklist by Daniel D. Beck_ ([link](https://github.com/ddbeck/readme-checklist/blob/master/checklist.md))
+[_README Checklist by Daniel D. Beck_](https://github.com/ddbeck/readme-checklist/blob/master/checklist.md)
 
 A series of the 4 ways to build confidence in your users from a readme, described in the talk Write the Readible Readme, that you can easily go through to evaluate your current readme and where it could use some love.
 
@@ -183,24 +183,24 @@ A series of the 4 ways to build confidence in your users from a readme, describe
 
 ---
 
-_Docosaurus_ ([link](http://docosaurus.io))
+[_Docosaurus_](http://docosaurus.io)
 
 Created by the Facebook Opensource Team to create a simple way to document projects.
 
-_tocdoc_ ([link](https://www.npmjs.com/package/doctoc))
+[_tocdoc_](https://www.npmjs.com/package/doctoc)
 
 Generates a Table Of Contents for markdown files automagically. Important flag: --github
 
-_allcontributors_ ([link](https://allcontributors.org/))
+[_allcontributors_](https://allcontributors.org/)
 
 A tool that will automatically add all of the contributors from a file to your project readme file.
 
 ---
 
-_docz_ ([link](https://www.docz.site))
+[_docz_](https://www.docz.site)
 
 Great project for documenting react projects with mdx. Also a great example of good documentation.
 
-_read the docs + sphinx_ ([link](readthedocs.io))
+[_read the docs + sphinx_](readthedocs.io)
 
 A free but add supported way to automatically build and host your docs. You can use standard markdown files in a docs directory and you will need to use python to configure initilaly.


### PR DESCRIPTION
This relates to how Assistive Technology exposes links on a page. 
In the previous version, if I tabbed through, I would find "Link", "Link", "Link". This is because the previous text (the context) does not get announced. The same would happen if I listed all the links on the page.
So, this PR puts the links as "wrapping" the context as well. They are visually distinct as links already, so the experience is now comparable for all users :)